### PR TITLE
Support for Suspense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Breaking Change
+- `AsyncState::Loading` is now a struct variant: `AsyncState::Loading { task: Task }`. All pattern matches must use `AsyncState::Loading { .. }` instead of `AsyncState::Loading`. This affects all provider and consumer code that matches on loading state.
 
 ## [0.0.5](https://github.com/wheregmis/dioxus-provider/compare/dioxus-provider-v0.0.4...dioxus-provider-v0.0.5) - 2025-07-08
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ fn App() -> Element {
             h1 { "Dioxus Provider Demo" }
             // Pattern match on the state to render UI
             match &*message.read() {
-                AsyncState::Loading => rsx! { div { "Loading..." } },
+                AsyncState::Loading { .. } => rsx! { div { "Loading..." } },
                 AsyncState::Success(data) => rsx! { div { "Server says: {data}" } },
                 AsyncState::Error(err) => rsx! { div { "Error: {err}" } },
             }

--- a/examples/cache_expiration_demo.rs
+++ b/examples/cache_expiration_demo.rs
@@ -404,7 +404,7 @@ fn CacheCard<T: 'static + Clone + PartialEq, E: 'static + Clone + PartialEq + st
     render_success: fn(&T) -> Element,
 ) -> Element {
     let cache_status = match &*data.read() {
-        AsyncState::Loading => "cache-miss",
+        AsyncState::Loading { .. } => "cache-miss",
         AsyncState::Success(_) => "cache-hit",
         AsyncState::Error(_) => "cache-error",
     };
@@ -424,7 +424,7 @@ fn CacheCard<T: 'static + Clone + PartialEq, E: 'static + Clone + PartialEq + st
             }
             div { class: "card-content",
                 match &*data.read() {
-                    AsyncState::Loading => rsx! {
+                    AsyncState::Loading { .. } => rsx! {
                         div { class: "loading-container",
                             div { class: "loading-spinner" }
                             span { "Cache expired - fetching fresh data..." }

--- a/examples/cache_expiration_test.rs
+++ b/examples/cache_expiration_test.rs
@@ -50,7 +50,7 @@ fn App() -> Element {
             div { style: "margin: 20px 0; padding: 20px; border: 1px solid #ccc;",
                 h3 { "Test Data (expires in 5s):" }
                 match &*data.read() {
-                    AsyncState::Loading => rsx! {
+                    AsyncState::Loading { .. } => rsx! {
                         div { style: "color: orange;",
                             "🔄 Loading data..."
                         }

--- a/examples/composable_provider_demo.rs
+++ b/examples/composable_provider_demo.rs
@@ -292,7 +292,7 @@ fn IndividualProvidersDemo(user_id: u32) -> Element {
             div { class: "card user-section",
                 h4 { "👤 User Data" }
                 match &*user_data.read() {
-                    AsyncState::Loading => rsx! { p { class: "loading", "Loading user..." } },
+                    AsyncState::Loading { .. } => rsx! { p { class: "loading", "Loading user..." } },
                     AsyncState::Success(user) => rsx! {
                         div {
                             p { strong { "Name: " } {user.name.clone()} }
@@ -308,7 +308,7 @@ fn IndividualProvidersDemo(user_id: u32) -> Element {
             div { class: "card permissions-section",
                 h4 { "🔐 Permissions" }
                 match &*permissions_data.read() {
-                    AsyncState::Loading => rsx! { p { class: "loading", "Loading permissions..." } },
+                    AsyncState::Loading { .. } => rsx! { p { class: "loading", "Loading permissions..." } },
                     AsyncState::Success(perms) => rsx! {
                         div {
                             p { strong { "Role: " } {perms.role.clone()} }
@@ -323,7 +323,7 @@ fn IndividualProvidersDemo(user_id: u32) -> Element {
             div { class: "card settings-section",
                 h4 { "⚙️ Settings" }
                 match &*settings_data.read() {
-                    AsyncState::Loading => rsx! { p { class: "loading", "Loading settings..." } },
+                    AsyncState::Loading { .. } => rsx! { p { class: "loading", "Loading settings..." } },
                     AsyncState::Success(settings) => rsx! {
                         div {
                             p { strong { "Theme: " } {settings.theme.clone()} }
@@ -345,7 +345,7 @@ fn ComposableProviderDemo(user_id: u32) -> Element {
     rsx! {
         div { class: "grid",
             match &*profile_data.read() {
-                AsyncState::Loading => rsx! {
+                AsyncState::Loading { .. } => rsx! {
                     div { class: "loading",
                         p { "⚡ Loading full profile in parallel..." }
                     }
@@ -406,7 +406,7 @@ fn PartialCompositionDemo(user_id: u32) -> Element {
     rsx! {
         div { class: "grid",
             match &*user_with_permissions.read() {
-                AsyncState::Loading => rsx! {
+                AsyncState::Loading { .. } => rsx! {
                     p { class: "loading", "Loading user with permissions..." }
                 },
                 AsyncState::Success(user_perms) => rsx! {

--- a/examples/comprehensive_demo.rs
+++ b/examples/comprehensive_demo.rs
@@ -568,7 +568,7 @@ fn ComprehensiveCacheTest() -> Element {
 fn LiveMetricsCard(data: Signal<AsyncState<LiveMetrics, String>>) -> Element {
     let refresh_metrics = use_invalidate_provider(fetch_live_metrics(), ());
     let status_class = match &*data.read() {
-        AsyncState::Loading => "loading",
+        AsyncState::Loading { .. } => "loading",
         AsyncState::Success(_) => "success",
         AsyncState::Error(_) => "error",
     };
@@ -599,7 +599,7 @@ fn LiveMetricsCard(data: Signal<AsyncState<LiveMetrics, String>>) -> Element {
             }
             div { class: "card-content",
                 match &*data.read() {
-                    AsyncState::Loading => rsx! {
+                    AsyncState::Loading { .. } => rsx! {
                         div { class: "loading-state",
                             div { class: "loading-spinner" }
                             span { "Loading data..." }
@@ -652,7 +652,7 @@ fn LiveMetricsCard(data: Signal<AsyncState<LiveMetrics, String>>) -> Element {
 fn UserDashboardCard(data: Signal<AsyncState<UserDashboard, String>>, user_id: u32) -> Element {
     let refresh_dashboard = use_invalidate_provider(fetch_user_dashboard(), user_id);
     let status_class = match &*data.read() {
-        AsyncState::Loading => "loading",
+        AsyncState::Loading { .. } => "loading",
         AsyncState::Success(_) => "success",
         AsyncState::Error(_) => "error",
     };
@@ -683,7 +683,7 @@ fn UserDashboardCard(data: Signal<AsyncState<UserDashboard, String>>, user_id: u
             }
             div { class: "card-content",
                 match &*data.read() {
-                    AsyncState::Loading => rsx! {
+                    AsyncState::Loading { .. } => rsx! {
                         div { class: "loading-state",
                             div { class: "loading-spinner" }
                             span { "Loading data..." }
@@ -726,7 +726,7 @@ fn UserDashboardCard(data: Signal<AsyncState<UserDashboard, String>>, user_id: u
 fn AnalyticsCard(data: Signal<AsyncState<AnalyticsReport, String>>) -> Element {
     let refresh_analytics = use_invalidate_provider(fetch_analytics_report(), ());
     let status_class = match &*data.read() {
-        AsyncState::Loading => "loading",
+        AsyncState::Loading { .. } => "loading",
         AsyncState::Success(_) => "success",
         AsyncState::Error(_) => "error",
     };
@@ -757,7 +757,7 @@ fn AnalyticsCard(data: Signal<AsyncState<AnalyticsReport, String>>) -> Element {
             }
             div { class: "card-content",
                 match &*data.read() {
-                    AsyncState::Loading => rsx! {
+                    AsyncState::Loading { .. } => rsx! {
                         div { class: "loading-state",
                             div { class: "loading-spinner" }
                             span { "Loading data..." }
@@ -809,7 +809,7 @@ fn AnalyticsCard(data: Signal<AsyncState<AnalyticsReport, String>>) -> Element {
 fn TempDataCard(data: Signal<AsyncState<TempSessionData, String>>, session_id: String) -> Element {
     let refresh_temp = use_invalidate_provider(fetch_temporary_data(), session_id);
     let status_class = match &*data.read() {
-        AsyncState::Loading => "loading",
+        AsyncState::Loading { .. } => "loading",
         AsyncState::Success(_) => "success",
         AsyncState::Error(_) => "error",
     };
@@ -840,7 +840,7 @@ fn TempDataCard(data: Signal<AsyncState<TempSessionData, String>>, session_id: S
             }
             div { class: "card-content",
                 match &*data.read() {
-                    AsyncState::Loading => rsx! {
+                    AsyncState::Loading { .. } => rsx! {
                         div { class: "loading-state",
                             div { class: "loading-spinner" }
                             span { "Loading data..." }
@@ -880,7 +880,7 @@ fn TempDataCard(data: Signal<AsyncState<TempSessionData, String>>, session_id: S
 fn ChatCard(data: Signal<AsyncState<ChatData, String>>, chat_id: u32) -> Element {
     let refresh_chat = use_invalidate_provider(fetch_chat_messages(), chat_id);
     let status_class = match &*data.read() {
-        AsyncState::Loading => "loading",
+        AsyncState::Loading { .. } => "loading",
         AsyncState::Success(_) => "success",
         AsyncState::Error(_) => "error",
     };
@@ -911,7 +911,7 @@ fn ChatCard(data: Signal<AsyncState<ChatData, String>>, chat_id: u32) -> Element
             }
             div { class: "card-content",
                 match &*data.read() {
-                    AsyncState::Loading => rsx! {
+                    AsyncState::Loading { .. } => rsx! {
                         div { class: "loading-state",
                             div { class: "loading-spinner" }
                             span { "Loading data..." }

--- a/examples/counter_mutation_demo.rs
+++ b/examples/counter_mutation_demo.rs
@@ -46,7 +46,7 @@ fn CounterApp() -> Element {
             },
             h2 { class: "text-lg font-semibold mt-4", "Provider State:" },
             match &*counter.read() {
-                AsyncState::Loading => rsx! { p { "Loading counter..." } },
+                AsyncState::Loading { .. } => rsx! { p { "Loading counter..." } },
                 AsyncState::Success(val) => rsx! { p { "Counter (from provider): {val}" } },
                 AsyncState::Error(err) => rsx! { p { "Error: {err}" } },
             },

--- a/examples/dependency_injection_demo.rs
+++ b/examples/dependency_injection_demo.rs
@@ -167,7 +167,7 @@ fn UserProfile(user_id: u32) -> Element {
             }
 
             match user() {
-                AsyncState::Loading => rsx! {
+                AsyncState::Loading { .. } => rsx! {
                     div { class: "loading", "Loading user..." }
                 },
                 AsyncState::Success(user) => rsx! {
@@ -183,7 +183,7 @@ fn UserProfile(user_id: u32) -> Element {
             }
 
             match posts() {
-                AsyncState::Loading => rsx! {
+                AsyncState::Loading { .. } => rsx! {
                     div { class: "loading", "Loading posts..." }
                 },
                 AsyncState::Success(posts) => rsx! {
@@ -223,7 +223,7 @@ fn CachedUserProfile(user_id: u32) -> Element {
             p { style: "color: #666; font-size: 0.9em;", "User ID: {user_id}" }
 
             match cached_user() {
-                AsyncState::Loading => rsx! {
+                AsyncState::Loading { .. } => rsx! {
                     div { class: "loading", "Loading cached user..." }
                 },
                 AsyncState::Success(user) => rsx! {
@@ -240,7 +240,7 @@ fn CachedUserProfile(user_id: u32) -> Element {
 
             h4 { "Fresh Posts (10s stale time)" }
             match fresh_posts() {
-                AsyncState::Loading => rsx! {
+                AsyncState::Loading { .. } => rsx! {
                     div { class: "loading", "Loading fresh posts..." }
                 },
                 AsyncState::Success(posts) => rsx! {

--- a/examples/interval_refresh_demo.rs
+++ b/examples/interval_refresh_demo.rs
@@ -189,7 +189,7 @@ fn SystemMetricsCard() -> Element {
             div { class: "card-header",
                 h3 { "System Metrics (5s interval)" }
                 div { class: match &*data.read() {
-                    AsyncState::Loading => "status loading",
+                    AsyncState::Loading { .. } => "status loading",
                     AsyncState::Error(_) => "status error",
                     AsyncState::Success(_) => "status success",
                 }}
@@ -199,7 +199,7 @@ fn SystemMetricsCard() -> Element {
 
             div { class: "card-content",
                 match &*data.read() {
-                    AsyncState::Loading => rsx! {
+                    AsyncState::Loading { .. } => rsx! {
                         div { class: "loading-state",
                             div { class: "spinner" }
                             span { "Loading..." }
@@ -249,7 +249,7 @@ fn BusinessMetricsCard() -> Element {
             div { class: "card-header",
                 h3 { "Business Metrics (10s interval)" }
                 div { class: match &*data.read() {
-                    AsyncState::Loading => "status loading",
+                    AsyncState::Loading { .. } => "status loading",
                     AsyncState::Error(_) => "status error",
                     AsyncState::Success(_) => "status success",
                 }}
@@ -259,7 +259,7 @@ fn BusinessMetricsCard() -> Element {
 
             div { class: "card-content",
                 match &*data.read() {
-                    AsyncState::Loading => rsx! {
+                    AsyncState::Loading { .. } => rsx! {
                         div { class: "loading-state",
                             div { class: "spinner" }
                             span { "Loading..." }
@@ -308,7 +308,7 @@ fn MetricsCard(
     color_class: String,
 ) -> Element {
     let status_class = match &*data.read() {
-        AsyncState::Loading => "status loading",
+        AsyncState::Loading { .. } => "status loading",
         AsyncState::Error(_) => "status error",
         AsyncState::Success(_) => "status success",
     };
@@ -324,7 +324,7 @@ fn MetricsCard(
 
             div { class: "card-content",
                 match &*data.read() {
-                    AsyncState::Loading => rsx! {
+                    AsyncState::Loading { .. } => rsx! {
                         div { class: "loading-state",
                             div { class: "spinner" }
                             span { "Loading..." }

--- a/examples/structured_errors_demo.rs
+++ b/examples/structured_errors_demo.rs
@@ -144,7 +144,7 @@ fn UserProfile(user_id: u32) -> Element {
             }
 
             match &*user_data.read() {
-                AsyncState::Loading => rsx! {
+                AsyncState::Loading { .. } => rsx! {
                     div { class: "text-blue-500", "Loading user..." }
                 },
                 AsyncState::Success(user) => rsx! {

--- a/examples/suspense_demo.rs
+++ b/examples/suspense_demo.rs
@@ -1,0 +1,50 @@
+use dioxus::prelude::*;
+use dioxus_provider::{hooks::SuspenseSignalExt, prelude::*};
+use std::time::Duration;
+
+// A simple provider that simulates a delayed async fetch
+#[provider(stale_time = "1s", cache_expiration = "10s")]
+async fn fetch_user(id: u32) -> Result<String, String> {
+    // Simulate network delay
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    if id == 0 {
+        Err("User not found".to_string())
+    } else {
+        Ok(format!("User #{}", id))
+    }
+}
+
+#[component]
+fn UserCard(id: u32) -> Element {
+    // Use the provider and suspend rendering until data is ready
+    let user = use_provider(fetch_user(), id).suspend()?;
+
+    match user {
+        Ok(name) => rsx!(div { "Loaded: {name}" }),
+        Err(err) => rsx!(div { "Error: {err}" }),
+    }
+}
+
+#[component]
+fn App() -> Element {
+    let mut user_id = use_signal(|| 1u32);
+
+    rsx! {
+        div { class: "container",
+            h1 { "Suspense Demo with dioxus-provider" }
+            button {
+                onclick: move |_| user_id += 1,
+                "Next User"
+            }
+            SuspenseBoundary {
+                fallback: |_| rsx!(div { "Loading user..." }),
+                UserCard { id: *user_id.read() }
+            }
+        }
+    }
+}
+
+fn main() {
+    init_global_providers();
+    launch(App);
+}

--- a/examples/swr_demo.rs
+++ b/examples/swr_demo.rs
@@ -242,7 +242,7 @@ fn SWRDataDisplay<
     render_success: fn(&T) -> Element,
 ) -> Element {
     match &*data.read() {
-        AsyncState::Loading => rsx! {
+        AsyncState::Loading { .. } => rsx! {
             div { class: "loading-container",
                 div { class: "loading-spinner" }
                 span { "Fetching fresh data..." }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -19,11 +19,13 @@ use std::time::Instant;
 #[cfg(target_family = "wasm")]
 use web_time::Instant;
 
+use dioxus_lib::prelude::Task;
+
 /// Represents the state of an async operation
 #[derive(Clone, PartialEq)]
 pub enum AsyncState<T, E> {
     /// The operation is currently loading
-    Loading,
+    Loading { task: Task },
     /// The operation completed successfully with data
     Success(T),
     /// The operation failed with an error
@@ -33,7 +35,7 @@ pub enum AsyncState<T, E> {
 impl<T, E> AsyncState<T, E> {
     /// Returns true if the state is currently loading
     pub fn is_loading(&self) -> bool {
-        matches!(self, AsyncState::Loading)
+        matches!(self, AsyncState::Loading { task: _ })
     }
 
     /// Returns true if the state contains successful data


### PR DESCRIPTION
Changed AsyncState::Loading from a unit variant to a struct variant holding a Task. Updated all pattern matches in examples and documentation to use AsyncState::Loading { .. }. Added SuspenseSignalExt for Dioxus SuspenseBoundary support, and introduced a new suspense_demo.rs example. This is a breaking change for all provider and consumer code matching on loading state.